### PR TITLE
chore: bump plugin.json to v0.2.3 + update download URLs

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "workflow-plugin-okta",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "description": "Okta identity and access management plugin",
     "author": "GoCodeAlone",
     "license": "MIT",
@@ -161,22 +161,22 @@
         {
             "os": "linux",
             "arch": "amd64",
-            "url": "https://github.com/GoCodeAlone/workflow-plugin-okta/releases/download/v0.2.2/workflow-plugin-okta-linux-amd64.tar.gz"
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-okta/releases/download/v0.2.3/workflow-plugin-okta-linux-amd64.tar.gz"
         },
         {
             "os": "linux",
             "arch": "arm64",
-            "url": "https://github.com/GoCodeAlone/workflow-plugin-okta/releases/download/v0.2.2/workflow-plugin-okta-linux-arm64.tar.gz"
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-okta/releases/download/v0.2.3/workflow-plugin-okta-linux-arm64.tar.gz"
         },
         {
             "os": "darwin",
             "arch": "amd64",
-            "url": "https://github.com/GoCodeAlone/workflow-plugin-okta/releases/download/v0.2.2/workflow-plugin-okta-darwin-amd64.tar.gz"
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-okta/releases/download/v0.2.3/workflow-plugin-okta-darwin-amd64.tar.gz"
         },
         {
             "os": "darwin",
             "arch": "arm64",
-            "url": "https://github.com/GoCodeAlone/workflow-plugin-okta/releases/download/v0.2.2/workflow-plugin-okta-darwin-arm64.tar.gz"
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-okta/releases/download/v0.2.3/workflow-plugin-okta-darwin-arm64.tar.gz"
         }
     ]
 }


### PR DESCRIPTION
Post-release cleanup: bump version and download URLs to v0.2.3.