### PR TITLE
fix: verify packaged manifest during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,8 +65,18 @@ jobs:
             jq '.[] | {name, type, goos, goarch, path}' dist/artifacts.json
             exit 0
           fi
+          ARCHIVE=$(jq -r --arg arch "$RUNNER_ARCH" \
+            '[.[] | select(.type=="Archive" and .goos=="linux" and .goarch==$arch and (.name|startswith("workflow-plugin-okta")))] | .[0].path // ""' \
+            dist/artifacts.json)
+          if [ -z "$ARCHIVE" ] || [ "$ARCHIVE" = "null" ]; then
+            echo "::warning::No matching linux/$RUNNER_ARCH archive in dist/artifacts.json; skipping verify-capabilities"
+            jq '.[] | {name, type, goos, goarch, path}' dist/artifacts.json
+            exit 0
+          fi
+          VERIFY_DIR=$(mktemp -d)
+          tar -xzf "$ARCHIVE" -C "$VERIFY_DIR" plugin.json plugin.contracts.json LICENSE
           chmod +x "$BIN"
-          "${{ runner.temp }}/wfctl-bin/wfctl" plugin verify-capabilities --binary "$BIN" .
+          "${{ runner.temp }}/wfctl-bin/wfctl" plugin verify-capabilities --binary "$BIN" "$VERIFY_DIR"
       - name: Publish GitHub release
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
Fixes release publish verification so wfctl compares the built binary against the plugin.json bundled in the release archive, not the source checkout manifest that intentionally stays at the previous version until sync.\n\nRoot cause observed on v0.2.5: verify-capabilities failed with version drift plugin.json=0.2.4 binary=0.2.5.\n\nVerification:\n- Downloaded goreleaser-dist artifact from failed Auth0 release run.\n- Confirmed packaged archive plugin.json is version 0.1.1 and includes required_secrets[].\n- Workflow now extracts matching linux archive into a temp verify dir and passes that to wfctl plugin verify-capabilities.