### PR TITLE
ci: canonical registry notify (fix dead dispatch + drop manifest-overwrite)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,60 +112,23 @@ jobs:
               });
             }
 
-  sync-registry:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [publish-release]
-    continue-on-error: true
+
+  notify-workflow-registry:
+    name: Notify workflow-registry
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: publish-release
+    if: >-
+      !github.event.deleted
+      && !contains(github.ref_name, '-')
+      && github.repository == 'GoCodeAlone/workflow-plugin-okta'
     steps:
-      - name: Check registry token
-        id: registry-token
-        env:
-          REGISTRY_PAT: ${{ secrets.REGISTRY_PAT }}
-        run: |
-          if [ -n "$REGISTRY_PAT" ]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Check out plugin
-        if: steps.registry-token.outputs.present == 'true'
-        uses: actions/checkout@v4
+      - name: Trigger registry manifest sync
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4
         with:
-          path: plugin
-
-      - name: Check out workflow-registry
-        if: steps.registry-token.outputs.present == 'true'
-        uses: actions/checkout@v4
-        with:
-          repository: GoCodeAlone/workflow-registry
-          token: ${{ secrets.REGISTRY_PAT }}
-          path: workflow-registry
-
-      - name: Update workflow-registry manifest
-        if: steps.registry-token.outputs.present == 'true'
-        run: |
-          registry_dir="$GITHUB_WORKSPACE/workflow-registry"
-          mkdir -p "$registry_dir/plugins/okta"
-          TAG=${GITHUB_REF#refs/tags/}
-          VERSION=${TAG#v}
-          jq --arg v "$VERSION" --arg tag "$TAG" '
-            .version = $v |
-            .downloads = ((.downloads // []) | map(.url |= sub("/releases/download/v[^/]+/"; "/releases/download/" + $tag + "/")))
-          ' "$GITHUB_WORKSPACE/plugin/plugin.json" > "$registry_dir/plugins/okta/manifest.json"
-          cd "$registry_dir"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add plugins/okta/manifest.json
-          git diff --cached --quiet || git commit -m "chore: sync okta plugin manifest v${VERSION}"
-          git push
-
-      - name: Notify workflow-registry
-        if: steps.registry-token.outputs.present == 'true'
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.REGISTRY_PAT }}
+          token: ${{ secrets.repo_dispatch_token }}
           repository: GoCodeAlone/workflow-registry
           event-type: plugin-release
-          client-payload: >-
-            {"plugin": "${{ github.repository }}", "tag": "${{ github.ref_name }}"}
-        continue-on-error: true
+          client-payload: |-
+            {"plugin": "okta", "tag": "${{ github.ref_name }}"}


### PR DESCRIPTION
## What

Aligns this release workflow's registry-notify with the fleet-canonical pattern used by ~49 plugin repos (e.g. workflow-plugin-aws): a `notify-workflow-registry` job that fires `repository-dispatch: plugin-release` to GoCodeAlone/workflow-registry on release, so the registry manifest auto-syncs (version + downloads + sha256, in place) via the registry's `sync-versions.sh`.

## Why (two bugs in the prior okta-derived `sync-registry` job)

1. **Dead notify payload.** It sent `{"plugin": "${{ github.repository }}"}` = `GoCodeAlone/workflow-plugin-<x>`. The registry resolver validates `plugin` against `^[A-Za-z0-9._-]+$` (no `/`) and requires `plugins/<plugin>/manifest.json` — so the slashed value was **silently rejected**; the dispatch never synced (only the daily cron did). Now sends the bare directory name.
2. **Regressing direct manifest-write (where present).** The old job also did `jq plugin.json > registry/plugins/<x>/manifest.json` + push, overwriting the registry manifest with lean `plugin.json` content (dropping `sha256`/`category`/`status`). Removed — the registry's own `sync-versions.sh --fix` (triggered by the dispatch) updates version/downloads/sha256 **in place**, preserving the hand-authored fields.

Also pins `peter-evans/repository-dispatch` to the fleet-standard SHA (`@28959ce8…  # v4`) and uses `secrets.repo_dispatch_token` (the token 49 repos use) instead of the inconsistent `REGISTRY_PAT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)